### PR TITLE
Don't open subscribe form in new tab.

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@ sitemap:
       <p>
         Know about new releases, features, blog posts, calls-for-help and more.
       </p>
-      <form action="//canonical.us3.list-manage.com/subscribe/post?u=56dac47c206ba0f58ec25f314&amp;id=36f7d8394e" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" target="_blank">
+      <form action="//canonical.us3.list-manage.com/subscribe/post?u=56dac47c206ba0f58ec25f314&amp;id=36f7d8394e" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form">
         <div class="col-6">
           <input type="email" value="" name="EMAIL" placeholder="Your email address" id="mce-EMAIL" required />
           <div class="u-off-screen" aria-hidden="true">


### PR DESCRIPTION
## Done

Now that MailChimp subscribe form redirects back to 'https://vanillaframework.io' we don't need to open it in new tab. If users use 'return to our website' button they will be redirected back to vanilla site (with subscribe form empty).

## QA

- Pull this branch
- Run server and go to home page
- Enter an email to subscribe form and hit Subscribe button
- Subscribe confirmation should open in same tab
- After completing subscription clicking on return button should go back to vanillaframework.io

## Issue / Card

Fixes #48

