### PR TITLE
Fix 404 links

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,7 @@
             <a class="p-footer__link" href="https://www.ubuntu.com/legal">Legal info</a>
           </li>
           <li class="p-footer__item">
-            <a class="p-footer__link" href="https://github.com/vanilla-framework/vanillaframework.io/issues/new">Report a bug with this site</a>
+            <a class="p-footer__link" href="https://github.com/canonical-websites/vanillaframework.io/issues/new">Report a bug with this site</a>
           </li>
           <li class="p-footer__item">
             <a class="p-footer__link" href="https://github.com/vanilla-framework/vanilla-framework/issues/new">Report a bug with Vanilla Framework</a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,7 +7,7 @@
         </a>
       </div>
       <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
-      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
     <nav class="p-navigation__nav">
       <span class="u-off-screen">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@ layout: compress
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
   {% include head.html %}
-  <body class="no-js">
+  <body>
     {% include header.html %}
       {{ content }}
     {% include footer.html %}

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ sitemap:
     lastmod: 2017-01-13T17:20:30+00:00
 ---
 
-<div class="p-strip--light is-deep u-no-padding--bottom">
+<div id="main-content" class="p-strip--light is-deep u-no-padding--bottom">
   <div class="row">
     <div class="col-6">
       <h1>Vanilla Framework</h1>

--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@ sitemap:
   <div class="row">
     <div class="col-5">
       <p>The recommended method of including Vanilla Framework in your project is via NPM. You can then simply include the framework in your SCSS files and compile.</p>
-      <p>For other methods, please see the <a href="#">advanced usage docs.</a></p>
+      <p>For other methods, please see the <a href="https://docs.vanillaframework.io/en/">advanced usage docs.</a></p>
     </div>
     <div class="col-7 prefix-1">
       <pre><code>npm install --save-dev vanilla-framework


### PR DESCRIPTION
## Done

- Fix footer link 404
- Remove redundant 'no-js' class from body
- Add #main-content id for 'Jump to content' link 

## QA
- Pull code
- Run `./run serve --watch`
- Check footer link 
- Check code for sanity

Fixes #52, Fixes #50 