### PR TITLE
Change ‘Getting started’ link to 'Quick start'

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,7 +14,7 @@
         <a href="#main-content">Jump to main content</a>
       </span>
       <ul class="p-navigation__links">
-        <li class="p-navigation__link"><a href="/#getting-started">Quick start</a></li>
+        <li class="p-navigation__link"><a href="/#quick-start">Quick start</a></li>
         <li class="p-navigation__link"><a href="https://docs.vanillaframework.io/en/">Docs</a></li>
         <li class="p-navigation__link"><a href="/accessibility">Accessibility</a></li>
         <li class="p-navigation__link"><a href="/browser-support">Browser support</a></li>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,7 +14,7 @@
         <a href="#main-content">Jump to main content</a>
       </span>
       <ul class="p-navigation__links">
-        <li class="p-navigation__link"><a href="#getting-started">Getting started</a></li>
+        <li class="p-navigation__link"><a href="/#getting-started">Quick start</a></li>
         <li class="p-navigation__link"><a href="https://docs.vanillaframework.io/en/">Docs</a></li>
         <li class="p-navigation__link"><a href="/accessibility">Accessibility</a></li>
         <li class="p-navigation__link"><a href="/browser-support">Browser support</a></li>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@ sitemap:
         written in Sass, by the Ubuntu Web Team.
       </p>
       <p>
-        <a href="#getting-started" class="p-button--positive">Get started</a>
+        <a href="#quick-start" class="p-button--positive">Get started</a>
         <a href="https://github.com/vanilla-framework/vanilla-framework" class="p-button--neutral">
           <span class="p-link--external">Vanilla on GitHub</span>
         </a>


### PR DESCRIPTION
## Done

This link more accurately reflects where the link actually points to. 

## QA

- Pull code
- View http://0.0.0.0:8014/
- Click link, checks it jumps to correct section in page

## Issue / Card

Fixes #54 https://github.com/canonical-websites/vanillaframework.io/issues/58