### PR TITLE
Replace get started CTA with see the docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@ sitemap:
         written in Sass, by the Ubuntu Web Team.
       </p>
       <p>
-        <a href="#quick-start" class="p-button--positive">Get started</a>
+        <a href="https://docs.vanillaframework.io/en/" class="p-button--positive">See the docs</a>
         <a href="https://github.com/vanilla-framework/vanilla-framework" class="p-button--neutral">
           <span class="p-link--external">Vanilla on GitHub</span>
         </a>
@@ -68,7 +68,7 @@ sitemap:
   </div>
 </div>
 
-<div id="getting-started" class="p-strip is-bordered is-deep">
+<div id="quick-start" class="p-strip is-bordered is-deep">
   <div class="row">
     <div class="col-12">
       <h2>Quick start</h2>


### PR DESCRIPTION
## Done
Replace the Get started CTA with See the docs button and drive by to fix the quick-start id.

## QA
- Run `./run`
- Go to http://0.0.0.0:8014
- Check that the primary CTA in the hero is to the docs not to quick start.
- Click the Quick start heading link and check it works 

## Issue / Card
Fixes https://github.com/canonical-websites/vanillaframework.io/issues/61

