### PR TITLE
Remove get started from the navigation

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,7 +14,6 @@
         <a href="#main-content">Jump to main content</a>
       </span>
       <ul class="p-navigation__links">
-        <li class="p-navigation__link"><a href="/#quick-start">Quick start</a></li>
         <li class="p-navigation__link"><a href="https://docs.vanillaframework.io/en/">Docs</a></li>
         <li class="p-navigation__link"><a href="/accessibility">Accessibility</a></li>
         <li class="p-navigation__link"><a href="/browser-support">Browser support</a></li>


### PR DESCRIPTION
## Done
Remove get started from the navigation

## QA
- Run `./run`
- Check that the primary navigation is now: Docs | Accessibility | Browser support | Coding standards | Contribute

## Issue / Card
Fixes https://github.com/canonical-websites/vanillaframework.io/issues/62

