### PR TITLE
Update text on homepage as themes are no more

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,12 +44,10 @@ sitemap:
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/ba665746-pictogram_extension01-dark.svg" />
-          <h3 class="p-heading-icon__title">Extendable</h3>
+          <h3 class="p-heading-icon__title">Composable</h3>
         </div>
         <p>
-          Vanilla is designed to be extended directly or by extension themes.
-          There are key themes for different types of sites, or you can create
-          your own theme that perfectly suits your project.
+          Vanilla is designed to be composable &mdash; you can include the whole framework to avail of all styles or you can use only what you need for your specific project.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

Update text on homepage as themes are no more

## QA

- Pull code
- Check new text
- Screenshot of new text below (middle section):

<img width="1086" alt="screen shot 2017-08-14 at 10 37 52" src="https://user-images.githubusercontent.com/505570/29266441-b2ac2cf6-80dc-11e7-930f-ee0422cc02a0.png">

## Issue / Card

Fixes #60 
