### PR TITLE
Correct capitalisation of ‘Vanilla Framework’

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-desc: File not found - Vanilla framework
+desc: File not found - Vanilla Framework
 sitemap:
     priority: 0.1
     changefreq: 'monthly'

--- a/500.html
+++ b/500.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-desc: Internal server error - Vanilla framework
+desc: Internal server error - Vanilla Framework
 sitemap:
     priority: 0.1
     changefreq: 'monthly'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vanillaframework.io
 
-This is the repo for the Vanilla framework brochure site
+This is the repo for the Vanilla Framework brochure site
 
 ## Local development
 

--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@
 
 # Site settings
 description: > # this means to ignore newlines until "baseurl:"
-    Vanilla framework
+    Vanilla Framework
 
 baseurl: "" # the subpath of your site, e.g. /blog
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,7 +9,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Vanilla framework</title>
+    <title>Vanilla Framework</title>
     <meta name="description" content="">
     <!-- Stylesheet -->
     <link rel="stylesheet" href="css/main.css">

--- a/accessibility.html
+++ b/accessibility.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-desc: Vanilla framework accessibility guidelines
+desc: Vanilla Framework accessibility guidelines
 sitemap:
     priority: 1.0
     changefreq: 'monthly'

--- a/browser-support.html
+++ b/browser-support.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-desc: Vanilla framework browser support
+desc: Vanilla Framework browser support
 sitemap:
     priority: 1.0
     changefreq: 'monthly'
@@ -11,7 +11,7 @@ sitemap:
   <div class="row">
     <div class="col-8">
       <h1>Browser support</h1>
-      <p>The Vanilla framework follows the principles of progressive enhancement and web standards. Users should be able to access core content and functionality from any browser or operating system, with varying degrees of access to visual and other enhancements — design patterns do not have to look exactly the same on every browser.
+      <p>The Vanilla Framework follows the principles of progressive enhancement and web standards. Users should be able to access core content and functionality from any browser or operating system, with varying degrees of access to visual and other enhancements — design patterns do not have to look exactly the same on every browser.
       </p>
       <h3>How bugs are prioritised</h3>
       <p>If the bug prevents access to core content (for example, by hiding it or covering it), it should be prioritised If the bug relates to visual differences that do not affect access to content on modern browsers, it should be queued up. Priority level should be determined case by case If the bug relates to visual differences that do not affect access to content on old browsers, it should be deprioritised, and potentially marked as “Won’t fix” (this should be decided case by case)</p>

--- a/coding-standards.html
+++ b/coding-standards.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-desc: Vanilla framework coding standards
+desc: Vanilla Framework coding standards
 sitemap:
     priority: 1.0
     changefreq: 'monthly'

--- a/contribute.html
+++ b/contribute.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-desc: Vanilla framework contribution guidelines
+desc: Vanilla Framework contribution guidelines
 sitemap:
     priority: 1.0
     changefreq: 'monthly'
@@ -11,7 +11,7 @@ sitemap:
   <div class="row">
     <div class="col-8">
       <h1>Contribute</h1>
-      <p>So, you'd like to contribute to Vanilla framework? Great!</p>
+      <p>So, you'd like to contribute to Vanilla Framework? Great!</p>
     </div>
   </div>
   <div class="row">

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@ sitemap:
 <div id="main-content" class="p-strip--light is-deep u-no-padding--bottom">
   <div class="row">
     <div class="col-6">
-      <h1>Vanilla framework</h1>
+      <h1>Vanilla Framework</h1>
       <p class="p-heading--four">
         Vanilla is a simple extensible CSS framework,
         written in Sass, by the Ubuntu Web Team.


### PR DESCRIPTION
## Done

Correct capitalisation of ‘Vanilla Framework’

## QA

- Pull code
- Run `./run serve --watch`
- Verify correct capitalisation across site

## Issue / Card

Fixes #74
