### PR TITLE
Import vanilla-framework directly, replacing VBT

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer class="p-footer">
+<footer class="p-footer u-no-margin--top">
   <div class="row">
     <div class="col-12">
       &copy; {{ "now" | date: "%Y" }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,6 +9,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="https://assets.ubuntu.com/v1/bbba0152-vanilla_favicon_16px.png" type="image/x-icon" />
     <title>Vanilla Framework</title>
     <meta name="description" content="">
     <!-- Stylesheet -->

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -13,12 +13,6 @@
 @include vfio-p-navigation;
 @include vfio-p-syntax-highlight;
 
-// Navigation bottom border
-// https://github.com/vanilla-framework/vanilla-framework/issues/1150
-header[class^="p-navigation"] {
-  border-bottom: 1px solid $color-mid-light;
-}
-
 // pre code blocks have margin-top
 // https://github.com/vanilla-framework/vanilla-framework/issues/1153
 pre:only-child {

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -13,19 +13,6 @@
 @include vfio-p-navigation;
 @include vfio-p-syntax-highlight;
 
-// Consecutive button fix
-// https://github.com/vanilla-framework/vanilla-framework/issues/1144
-button,
-[class^="p-button"] {
-
-  & + & {
-
-    @media (min-width: $breakpoint-medium) {
-      margin-left: $sp-small;
-    }
-  }
-}
-
 // Temp fix Footer links does not follow spec
 // https://github.com/vanilla-framework/vanilla-framework/issues/1149
 .p-footer {

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -12,3 +12,9 @@
 @import 'patterns_syntax-highlight';
 @include vfio-p-navigation;
 @include vfio-p-syntax-highlight;
+
+// fix .p-link---external colors
+// https://github.com/vanilla-framework/vanilla-framework/issues/1274
+.p-strip .p-link--external {
+  color: $color-link;
+}

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -5,7 +5,7 @@
 @import 'settings_colors';
 
 // import vanilla
-@import 'vanilla-brochure-theme/scss/theme';
+@import '../node_modules/vanilla-framework/scss/build';
 @include vanilla-brochure-theme;
 
 @import 'patterns_navigation';

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -12,9 +12,3 @@
 @import 'patterns_syntax-highlight';
 @include vfio-p-navigation;
 @include vfio-p-syntax-highlight;
-
-// pre code blocks have margin-top
-// https://github.com/vanilla-framework/vanilla-framework/issues/1153
-pre:only-child {
-  margin-top: 0 !important;
-}

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -13,12 +13,6 @@
 @include vfio-p-navigation;
 @include vfio-p-syntax-highlight;
 
-// Equal height wrapper adds margin-bottom
-// https://github.com/vanilla-framework/vanilla-framework/issues/1152
-.u-equal-height {
-  margin-bottom: 0 !important;
-}
-
 // Navigation bottom border
 // https://github.com/vanilla-framework/vanilla-framework/issues/1150
 header[class^="p-navigation"] {

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -13,43 +13,6 @@
 @include vfio-p-navigation;
 @include vfio-p-syntax-highlight;
 
-// Temp fix Footer links does not follow spec
-// https://github.com/vanilla-framework/vanilla-framework/issues/1149
-.p-footer {
-  border-top: 1px solid $color-mid-light;
-  padding: $sp-large 0 0;
-
-  @media (max-width: $breakpoint-medium) {
-
-    nav {
-      margin-bottom: 0 !important;
-    }
-
-    ul {
-      margin-top: $sp-medium;
-    }
-  }
-
-  @media (min-width: $breakpoint-medium) {
-
-    nav,
-    & {
-      margin-bottom: .5rem !important; // specicifity
-    }
-  }
-}
-
-.p-footer__link {
-  position: relative;
-}
-
-.p-footer__link::after {
-  left: auto;
-  position: absolute;
-  right: -.75rem;
-  top: -.65rem;
-}
-
 // Equal height wrapper adds margin-bottom
 // https://github.com/vanilla-framework/vanilla-framework/issues/1152
 .u-equal-height {

--- a/accessibility.html
+++ b/accessibility.html
@@ -75,7 +75,7 @@ sitemap:
         <li><a class="p-link--external" href="http://www.chromevox.com/">ChromeVox: a screen reader for Chrome</a></li>
         <li><a class="p-link--external" href="https://tenon.io/index.php">Tenon.io: analyse your site’s accessibility</a></li>
       </ul>
-      <p>If you think we could improve Vanilla’s accessibility in any way, let us know by <a href="https://github.com/vanilla-framework/vanilla-framework/issues">filing an issue</a> on GitHub.
+      <p>If you think we could improve Vanilla’s accessibility in any way, let us know by <a href="https://github.com/vanilla-framework/vanilla-framework/issues" class="p-link--external">filing an issue</a> on GitHub.
       </p>
       <p>Last updated: {{ page.sitemap.lastmod | date: '%d %B %Y'}}</p>
     </div>

--- a/contribute.html
+++ b/contribute.html
@@ -12,10 +12,6 @@ sitemap:
     <div class="col-8">
       <h1>Contribute</h1>
       <p>So, you'd like to contribute to Vanilla Framework? Great!</p>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-8">
       <h2>Bugs and issues</h2>
       <p>We use the <a class="p-link--external" href="https://github.com/vanilla-framework/vanilla-framework/issues">GitHub issues</a> to track all our bugs and feature requests.</p>
       <p>When <a class="p-link--external" href="https://github.com/vanilla-framework/vanilla-framework/issues/new">submitting a new issue</a>, please check that it hasn't already been raised by someone else. We've provided a template for new issues which will help you structure your issue to ensure it can be picked up and actioned easily.</p>
@@ -26,7 +22,7 @@ sitemap:
       <p>Before proposing a pull request, ensure that the tests pass on your local fork. To kick off the tests, run <code>./run test</code>.</p>
       <h2>Licences</h2>
       <p>The content of this project is licensed under the <a class="p-link--external" href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International license</a>, and the underlying code used to format and display that content is licensed under the <a class="p-link--external" href="http://opensource.org/licenses/lgpl-3.0.html">LGPLv3</a> by <a class="p-link--external" href="http://www.canonical.com/">Canonical Ltd.</a></p>
-      <p>Last updated: {{ page.sitemap.lastmod | date: '%d %B %Y'}}</p>
+      <p>Last updated: <time>{{ page.sitemap.lastmod | date: '%d %B %Y'}}</time></p>
     </div>
   </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ sitemap:
     lastmod: 2017-01-13T17:20:30+00:00
 ---
 
-<div id="main-content" class="p-strip--light is-deep u-no-padding--bottom">
+<div id="main-content" class="p-strip is-deep u-no-padding--bottom">
   <div class="row">
     <div class="col-6">
       <h1>Vanilla Framework</h1>
@@ -25,7 +25,7 @@ sitemap:
   </div>
 </div>
 
-<div class="p-strip--light is-bordered is-deep">
+<div class="p-strip is-bordered is-deep">
   <div class="row">
     <div class="col-4">
       <div class="p-heading-icon">

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "babel-core": "^6.23.1",
     "babel-preset-es2015": "^6.22.0",
     "node-sass": "^4.5.3",
-    "vanilla-brochure-theme": "1.0.8"
+    "vanilla-framework": "1.4.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3116,15 +3116,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-brochure-theme@1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/vanilla-brochure-theme/-/vanilla-brochure-theme-1.0.8.tgz#be6c74ad6f60b5e03171426a2f5f4012b3c12a42"
-  dependencies:
-    vanilla-framework "1.4.x"
-
-vanilla-framework@1.4.x:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.4.1.tgz#6cb1884fb8337891f5f271861099108b5805c5d3"
+vanilla-framework@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.4.3.tgz#259386f083fcaa8193c22bad6a3d1148e0cc4481"
 
 verror@1.3.6:
   version "1.3.6"


### PR DESCRIPTION
## Done

- Import `vanilla-framework` directly instead of using `vanilla-brochure-theme`
- Remove temp fixes which have now moved upstream to Vanilla
- Pulling Vanilla directly has squashed the nav hover bug as outlined in #70 

## QA

- Pull code
- Run `./run serve --watch`
- Verify nothing has broken (oh, where art thou Percy!)
- Check there is now no underline when hovering over primary nav items

## Issue / Card

Fixes #70 
