### PR TITLE
Fix missing links in the guidelines section

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,13 +98,13 @@ sitemap:
         </p>
         <ul class="p-list--divided">
           <li class="p-list__item">
-            <a href="" class="p-link--soft">Accessibility&nbsp;&rsaquo;</a>
+            <a href="https://vanillaframework.io/accessibility" class="p-link--soft">Accessibility&nbsp;&rsaquo;</a>
           </li>
           <li class="p-list__item">
-            <a href="" class="p-link--soft">Browser support&nbsp;&rsaquo;</a>
+            <a href="https://vanillaframework.io/browser-support" class="p-link--soft">Browser support&nbsp;&rsaquo;</a>
           </li>
           <li class="p-list__item">
-            <a href="" class="p-link--soft">Coding standards&nbsp;&rsaquo;</a>
+            <a href="https://vanillaframework.io/coding-standards" class="p-link--soft">Coding standards&nbsp;&rsaquo;</a>
           </li>
         </ul>
       </div>

--- a/index.html
+++ b/index.html
@@ -98,13 +98,13 @@ sitemap:
         </p>
         <ul class="p-list--divided">
           <li class="p-list__item">
-            <a href="https://vanillaframework.io/accessibility" class="p-link--soft">Accessibility&nbsp;&rsaquo;</a>
+            <a href="/accessibility" class="p-link--soft">Accessibility&nbsp;&rsaquo;</a>
           </li>
           <li class="p-list__item">
-            <a href="https://vanillaframework.io/browser-support" class="p-link--soft">Browser support&nbsp;&rsaquo;</a>
+            <a href="/browser-support" class="p-link--soft">Browser support&nbsp;&rsaquo;</a>
           </li>
           <li class="p-list__item">
-            <a href="https://vanillaframework.io/coding-standards" class="p-link--soft">Coding standards&nbsp;&rsaquo;</a>
+            <a href="/coding-standards" class="p-link--soft">Coding standards&nbsp;&rsaquo;</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Done

Add the missing links into the guidelines section of the homepage

## QA

Manually via;

- Load vanillaframework.io (tested in both Firefox and Chromium)
- Scroll down to Guideline section
- Le click

Or with a link checker. I.e. Integrity

## Issue / Card

Fixes #97 
