### PR TITLE
101: Add Downloads section to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,46 @@ sitemap:
   </div>
 </div>
 
+<div class="p-strip is-bordered is-deep">
+  <div class="row">
+    <div class="col-12">
+      <h2>Downloads</h2>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a81f84ba-github-icon.svg" alt="GitHub icon">
+          <h3 class="p-heading-icon__title">Vanilla Framework</h3>
+        </div>
+        <p>Use our CSS framework to start building your project.</p>
+        <p>
+          <a class="p-link--strong p-link--external" href="https://github.com/vanilla-framework/vanilla-framework">Download Vanilla Framework</a>
+          <p class="u-no-margin--top">
+            <small class="u-no-margin--top">See the <a class="p-link--external" href="https://github.com/vanilla-framework/vanilla-framework/releases">release notes</a> for details on the latest updates.</small>
+          </p>
+        </p>
+      </div>
+    </div>
+    <div class="col-6">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/286cacab-sketch-icon.svg" alt="Sketch icon">
+          <h3 class="p-heading-icon__title">Vanilla Design</h3>
+        </div>
+        <p>Get a Sketch file of common design components.</p>
+        <p>
+          <a class="p-link--strong p-link--external" href="https://github.com/ubuntudesign/vanilla-design/blob/master/vanilla-framework-1.6.2.sketch">Download Vanilla Design UI Kit</a>
+          <p class="u-no-margin--top">
+            <small class="u-no-margin--top">(2.4 MB)</small>
+          </p>
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
 <div class="p-strip is-bordered is-shallow">
   <div class="row">
     <h2 class="p-muted-heading u-align--center">Who&rsquo;s using Vanilla</h2>


### PR DESCRIPTION
# Done

- Added "Downloads" section to homepage as per #101 
- Changed the homepage to have alternating white/light strips.

## QA

- Pull code
- Run `./run serve --watch`
- Navigate to http://0.0.0.0:8014/
- Check that there is a new Downloads section that looks like [the proposed design](https://github.com/canonical-websites/vanillaframework.io/issues/101)
- Check that the text matches [the copydoc](https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g7O3rLzpg/edit#)

## Issue / Card

Fixes #101 
