### PR TITLE
Update site to Vanilla 1.6.6

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,10 +14,10 @@
     </span>
     <ul class="p-navigation__links">
       <li class="p-navigation__link"><a href="https://docs.vanillaframework.io/en/">Docs</a></li>
-      <li class="p-navigation__link"><a href="/accessibility">Accessibility</a></li>
-      <li class="p-navigation__link"><a href="/browser-support">Browser support</a></li>
-      <li class="p-navigation__link"><a href="/coding-standards">Coding standards</a></li>
-      <li class="p-navigation__link"><a href="/contribute">Contribute</a></li>
+      <li class="p-navigation__link{% if page.url == '/accessibility.html' %} is-selected{% endif %}"><a href="/accessibility">Accessibility</a></li>
+      <li class="p-navigation__link{% if page.url == '/browser-support.html' %} is-selected{% endif %}"><a href="/browser-support">Browser support</a></li>
+      <li class="p-navigation__link{% if page.url == '/coding-standards.html' %} is-selected{% endif %}"><a href="/coding-standards">Coding standards</a></li>
+      <li class="p-navigation__link{% if page.url == '/contribute.html' %} is-selected{% endif %}"><a href="/contribute">Contribute</a></li>
     </ul>
   </nav>
 </header>

--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@ sitemap:
         </div>
         <p>Get a Sketch file of common design components.</p>
         <p>
-          <a class="p-link--strong p-link--external" href="https://github.com/ubuntudesign/vanilla-design/blob/master/vanilla-framework-1.6.4.sketch">Download Vanilla Design UI Kit</a>
+          <a class="p-link--strong p-link--external" href="https://github.com/ubuntudesign/vanilla-design">Download Vanilla Design UI Kit</a>
           <p class="u-no-margin--top">
             <small class="u-no-margin--top">(2.4 MB)</small>
           </p>

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "babel-core": "^6.23.1",
     "babel-preset-es2015": "^6.22.0",
     "node-sass": "^4.5.3",
-    "vanilla-framework": "1.6.3"
+    "vanilla-framework": "1.6.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3116,9 +3116,9 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vanilla-framework@1.6.3:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.6.3.tgz#92271d5dc765d7563659684ed4797e3919160f01"
+vanilla-framework@1.6.6:
+  version "1.6.6"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-1.6.6.tgz#705125b34f9317e7af8f30b62c10f303cb482767"
 
 verror@1.3.6:
   version "1.3.6"


### PR DESCRIPTION
## Done

- Updated to Vanilla 1.6.6
- Added marker to header nav to show which tab is selected (as per 1.6.6 design update)
- Changed url of Sketch file to https://github.com/ubuntudesign/vanilla-design until the process is automated

## QA

- Check the header nav works, and shows the correct tab selected
- Check that the Sketch file link on the homepage links to https://github.com/ubuntudesign/vanilla-design
- Go over the site and make sure Vanilla 1.6.6 hasn't broken anything
