### PR TITLE
Point sketch file link to a "latest version" redirect

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,7 +145,7 @@ sitemap:
         </div>
         <p>Get a Sketch file of common design components.</p>
         <p>
-          <a class="p-link--strong p-link--external" href="https://github.com/ubuntudesign/vanilla-design">Download Vanilla Design UI Kit</a>
+          <a class="p-link--strong p-link--external" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download Vanilla Design UI Kit</a>
           <p class="u-no-margin--top">
             <small class="u-no-margin--top">(2.4 MB)</small>
           </p>


### PR DESCRIPTION
Update the sketch file link on the home page to point to a "latest version" link.
https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch

We will then update this link as needed, pointing to the latest file.

Fixes #119