### PR TITLE
Update homepage hero strip

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -9,3 +9,21 @@
 
 @import 'patterns_syntax-highlight';
 @include vfio-p-syntax-highlight;
+
+// XXX Caleb 29/05: Proposal to be included upstream in Vanilla
+// https://github.com/vanilla-framework/vanilla-framework/issues/1841
+.p-heading--stylized {
+  font-weight: 100;
+}
+
+// XXX Caleb 29/05: Temp fix for links that follow a button pattern
+// https://github.com/vanilla-framework/vanilla-framework/issues/1840
+.p-button--neutral + a {
+  margin-left: $sph-inter--expanded;
+
+  @media only screen and (max-width: $breakpoint-x-small) {
+    display: block;
+    margin-left: 0;
+    text-align: center;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -7,14 +7,11 @@ sitemap:
     lastmod: 2017-01-13T17:20:30+00:00
 ---
 
-<div id="main-content" class="p-strip is-deep u-no-padding--bottom">
+<div id="main-content" class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/e9a3f1af-vanilla-suru-background.png'); background-position: 75% 50%;">
   <div class="row">
-    <h1>Vanilla Framework</h1>
-    <h2 class="p-heading--four">
-      Vanilla is a simple extensible CSS framework, written in Sass, by the Ubuntu Web Team.
-    </h2>
-    <a href="https://docs.vanillaframework.io/en/" class="p-button--positive">See the docs</a>
-    <a href="https://github.com/vanilla-framework/vanilla-framework" class="p-button--neutral p-link--external">Vanilla on GitHub</a>
+    <h1 class="p-heading--stylized">Vanilla is a simple extensible CSS framework, written in Sass, by the Ubuntu Web Team</h1>
+    <a href="https://docs.vanillaframework.io/en/" class="p-button--neutral">See the docs</a>
+    <a href="https://github.com/vanilla-framework/vanilla-framework" class="p-link--external p-link--inverted">Vanilla on GitHub</a>
   </div>
 </div>
 


### PR DESCRIPTION
## Don't merge. This PR contains a little bit of bespoke styling that I think should be merged upstream in Vanilla before this is released.

## Done

- Updated hero strip to match [design](https://github.com/ubuntudesign/vanillaframework.io-design/tree/master/Suru%20background)

## QA

- Pull code, `./run`, go to http://0.0.0.0:8014/
- Check that the hero strip matches the [design](https://github.com/ubuntudesign/vanillaframework.io-design/tree/master/Suru%20background)

## Issue / Card

Fixes ubuntudesign/vanillaframework.io-design#8

## Screenshots

![0 0 0 0_8014_](https://user-images.githubusercontent.com/25733845/40555075-d9af8d28-603f-11e8-8512-20cdc8a52c69.png)

