### PR TITLE
Update 404 page and make footer sticky

### DIFF
--- a/404.html
+++ b/404.html
@@ -7,19 +7,9 @@ sitemap:
     lastmod: 2017-08-02T17:20:30+00:00
 ---
 
-<div class="p-strip--light is-deep u-no-padding--bottom">
+<div class="p-strip is-deep">
   <div class="row">
-    <div class="u-equal-height">
-      <div class="col-6 u-vertically-center">
-      <div>
-        <h1>404: Page not found</h1>
-        <p class="p-heading--four">Sorry, we can't find the page you're looking for.</p>
-        <p>If you think this is an error on our site, please <a class="p-link--external" href="https://github.com/canonical-websites/vanillaframework.io/issues/new">file a bug.</a></p>
-      </div>
-    </div>
-      <div class="col-6">
-      <img src="https://assets.ubuntu.com/v1/bcdcf2c8-image-404.svg" alt="">
-    </div>
-    </div>
+    <h1>404: Page not found</h1>
+    <p class="p-heading--four" style="max-width: none">Sorry, we can't find the page you're looking for.<br>If you think this is an error on our site, please <a class="p-link--external" href="https://github.com/canonical-websites/vanillaframework.io/issues/new">file a bug.</a></p>
   </div>
 </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,4 @@
-<footer class="p-footer u-no-margin--top">
+<footer class="p-footer">
   <div class="row">
     <div class="col-12">
       &copy; {{ "now" | date: "%Y" }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.

--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -3,9 +3,10 @@
 // import settings
 @import 'settings_breakpoints';
 @import 'settings_colors';
+$sticky-footer: true;
 
 // import vanilla
-@import '../node_modules/vanilla-framework/scss/build';
+@import 'vanilla-framework/scss/build';
 
 @import 'patterns_syntax-highlight';
 @include vfio-p-syntax-highlight;
@@ -26,4 +27,9 @@
     margin-left: 0;
     text-align: center;
   }
+}
+
+// XXX 31/05: Temp fix for sticky footer not working
+.p-footer {
+  margin-top: auto;
 }


### PR DESCRIPTION
## Done

- Updated 404 page with new [design](https://user-images.githubusercontent.com/17748020/40728689-9afac8ea-6422-11e8-95b8-9f4f630d7244.png)
- Made footer stick to bottom of page

## QA

- Go to `http://0.0.0.0:8014/123123`
- Check that the page matches the [design](https://user-images.githubusercontent.com/17748020/40728689-9afac8ea-6422-11e8-95b8-9f4f630d7244.png)

## Issue / Card

Fixes #114 
