### PR TITLE
Add event tracking to vf.io homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@ sitemap:
 <div id="main-content" class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/e9a3f1af-vanilla-suru-background.png'); background-position: 75% 50%;">
   <div class="row">
     <h1 class="p-heading--stylized">Vanilla is a simple extensible CSS framework, written in Sass, by the Ubuntu Web Team</h1>
-    <a href="https://docs.vanillaframework.io/en/" class="p-button--neutral">See the docs</a>
-    <a href="https://github.com/vanilla-framework/vanilla-framework" class="p-link--external p-link--inverted">Vanilla on GitHub</a>
+    <a href="https://docs.vanillaframework.io/en/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Docs link', 'eventLabel' : 'See the docs', 'eventValue' : undefined });" class="p-button--neutral">See the docs</a>
+    <a href="https://github.com/vanilla-framework/vanilla-framework" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'GitHub link', 'eventLabel' : 'Vanilla on GitHub', 'eventValue' : undefined });" class="p-link--external p-link--inverted">Vanilla on GitHub</a>
   </div>
 </div>
 
@@ -120,7 +120,7 @@ sitemap:
         </div>
         <p>Use our CSS framework to start building your project.</p>
         <p class="u-no-margin--bottom">
-          <a class="p-link--strong p-link--external" href="https://github.com/vanilla-framework/vanilla-framework">Download Vanilla Framework</a>
+          <a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-link--strong p-link--external" href="https://github.com/vanilla-framework/vanilla-framework">Download Vanilla Framework</a>
         </p>
         <small>See the <a class="p-link--external" href="https://github.com/vanilla-framework/vanilla-framework/releases">release notes</a> for details on the latest updates.</small>
       </div>
@@ -133,7 +133,7 @@ sitemap:
         </div>
         <p>Get a Sketch file of common design components.</p>
         <p class="u-no-margin--bottom">
-          <a class="p-link--strong p-link--external" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download Vanilla Design UI Kit</a>
+          <a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla Design UI Kit', 'eventValue' : undefined });" class="p-link--strong p-link--external" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download Vanilla Design UI Kit</a>
         </p>
         <small>(2.4 MB)</small>
       </div>
@@ -198,7 +198,7 @@ sitemap:
           </div>
         </div>
         <div class="col-2">
-          <button type="submit" class="p-button">Subscribe</button>
+          <button type="submit" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Subscribe', 'eventLabel' : 'Subcribe to Vanilla updates', 'eventValue' : undefined });" class="p-button">Subscribe</button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## Done

Add event tracking to the homepage of vanillaframework.io.
- Hero section
- Downloads section
- Subscribe section

## QA

Check onclick events have been added to buttons/links on the homepage.
- 'eventCategory', eventAction' and 'eventLabel'

## Issue / Card

Fixes #121, fixes #122, fixes #123 
