### PR TITLE
Remove custom scss for button + link

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -17,18 +17,6 @@ $sticky-footer: true;
   font-weight: 100;
 }
 
-// XXX Caleb 29/05: Temp fix for links that follow a button pattern
-// https://github.com/vanilla-framework/vanilla-framework/issues/1840
-.p-button--neutral + a {
-  margin-left: $sph-inter--expanded;
-
-  @media only screen and (max-width: $breakpoint-x-small) {
-    display: block;
-    margin-left: 0;
-    text-align: center;
-  }
-}
-
 // XXX 31/05: Temp fix for sticky footer not working
 .p-footer {
   margin-top: auto;

--- a/index.html
+++ b/index.html
@@ -10,8 +10,14 @@ sitemap:
 <div id="main-content" class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/775cc62b-vanilla-grad-background.png'); background-position: 75% 50%;">
   <div class="row">
     <h1 class="p-heading--stylized">Vanilla is a simple extensible CSS framework, written in Sass, by the Ubuntu Web Team</h1>
-    <a href="https://docs.vanillaframework.io/en/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Docs link', 'eventLabel' : 'See the docs', 'eventValue' : undefined });" class="p-button--neutral">See the docs</a>
-    <a href="https://github.com/vanilla-framework/vanilla-framework" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'GitHub link', 'eventLabel' : 'Vanilla on GitHub', 'eventValue' : undefined });" class="p-link--external p-link--inverted">Vanilla on GitHub</a>
+    <ul class="p-inline-list">
+      <li class="p-inline-list__item">
+        <a href="https://docs.vanillaframework.io/en/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Docs link', 'eventLabel' : 'See the docs', 'eventValue' : undefined });" class="p-button--neutral">See the docs</a>
+      </li>
+      <li class="p-inline-list__item">
+        <a href="https://github.com/vanilla-framework/vanilla-framework" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'GitHub link', 'eventLabel' : 'Vanilla on GitHub', 'eventValue' : undefined });" class="p-link--external p-link--inverted">Vanilla on GitHub</a>
+      </li>
+    </ul>
   </div>
 </div>
 


### PR DESCRIPTION
## Done

- Removed custom scss for button + link in hero strip, and rewrote as an inline list

## QA

- `./run`
- Go to http://0.0.0.0:8014/
- Check the hero strip looks the same
- On mobile the link is now on the left to keep consistent with Vanilla framework
