### PR TITLE
Added snap logo and fixed logo class

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -11,6 +11,11 @@ $sticky-footer: true;
 @import 'patterns_syntax-highlight';
 @include vfio-p-syntax-highlight;
 
+// XXX Remove when updated to Vanilla >1.7.1
+.p-inline-images__logo {
+  width: 100%;
+}
+
 // XXX Caleb 29/05: Proposal to be included upstream in Vanilla
 // https://github.com/vanilla-framework/vanilla-framework/issues/1841
 .p-heading--stylized {

--- a/index.html
+++ b/index.html
@@ -164,8 +164,6 @@ sitemap:
         <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/4cd5caa2-maas_black-orange_hex.svg" alt="MAAS" />
         </li>
-      </ul>
-      <ul class="p-inline-images u-no-margin--top">
         <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/e2ac88af-juju_black-orange_hex.svg" alt="Juju" />
         </li>
@@ -178,8 +176,6 @@ sitemap:
         <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/ea4e7803-snapcraft_green-red_su_hex_cropped.svg" alt="Snapcraft" />
         </li>
-      </ul>
-      <ul class="p-inline-images u-no-margin--top">
         <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d9c7e58e-cloud-init-logo-updated.svg" alt="Cloud Init" />
         </li>

--- a/index.html
+++ b/index.html
@@ -151,17 +151,39 @@ sitemap:
   <div class="row">
     <h2 class="p-muted-heading u-align-text--center">Who&rsquo;s using Vanilla</h2>
     <div class="col-12">
-      <div class="p-inline-images">
-        <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical" />
-        <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" />
-        <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/4a93b95f-landscape_black-orange_hex.svg" alt="Landscape" />
-        <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/4cd5caa2-maas_black-orange_hex.svg" alt="MAAS" />
-        <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/2d41eab7-juju_black-orange_hex.svg" alt="Juju" />
-        <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/5051e6e5-core_logo.svg" alt="Ubuntu Core" />
-        <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/8c237d84-conjure-up-logo-black.svg" alt="Conjure Up" />
-        <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/d45097a4-snapcraft.io-logotype.svg" alt="Snapcraft" />
-        <img class="p-inline-images__img" src="https://assets.ubuntu.com/v1/c7c50d24-image.svg" alt="Cloud Init" />
-      </div>
+      <ul class="p-inline-images">
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical" />
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" />
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/4a93b95f-landscape_black-orange_hex.svg" alt="Landscape" />
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/4cd5caa2-maas_black-orange_hex.svg" alt="MAAS" />
+        </li>
+      </ul>
+      <ul class="p-inline-images u-no-margin--top">
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/e2ac88af-juju_black-orange_hex.svg" alt="Juju" />
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/5051e6e5-core_logo.svg" alt="Ubuntu Core" />
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/8c237d84-conjure-up-logo-black.svg" alt="Conjure Up" />
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/ea4e7803-snapcraft_green-red_su_hex_cropped.svg" alt="Snapcraft" />
+        </li>
+      </ul>
+      <ul class="p-inline-images u-no-margin--top">
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d9c7e58e-cloud-init-logo-updated.svg" alt="Cloud Init" />
+        </li>
+      </ul>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Done

- Updated Snapcraft logo
- Updated logo class, making each logo span over 4 cols. 

## QA

Run demo and go down to "Who's using Vanilla" section.

## Issue / Card

Fixes: #133 

