### PR TITLE
Update Twitter social link

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,7 +196,7 @@ sitemap:
           </a>
         </li>
         <li class="p-list__item is-ticked" style="background-image: url('https://assets.ubuntu.com/v1/7546afeb-icon-twitter.svg'); padding-left: 2.125rem; padding-top: .55rem;">
-          <a href="https://mobile.twitter.com/vanillaframewrk"
+          <a href="https://twitter.com/vanillaframewrk"
             class="p-link--soft">
             Twitter&nbsp;&rsaquo;
           </a>


### PR DESCRIPTION
## Done

- Updated Twitter social link on 'Get involved' section
- Previously it was linking to mobile version

## QA

- Check link works and displays desktop version of Twitter

## Screenshots
![screen shot 2018-06-18 at 16 42 05](https://user-images.githubusercontent.com/17748020/41547160-57e46d1e-7317-11e8-85ad-71ceaedb18d6.png)
