### PR TITLE
Update coding stadards page

### DIFF
--- a/coding-standards.html
+++ b/coding-standards.html
@@ -15,11 +15,14 @@ sitemap:
 <div class="p-strip">
   <div class="row">
     <div class="col-8">
-      <p>If you are contributing to Vanilla, there are two guideline documents that you need to follow, that align with the practices that the Canonical Web Team follows across all projects.</p>
-      <ul>
-       <li><a class="p-link--external" href="https://github.com/canonical-webteam/practices/blob/master/coding/html.md">HTML code standards</a></li>
-       <li><a class="p-link--external" href="https://github.com/canonical-webteam/practices/blob/master/coding/stylesheets.md">Stylesheets code standards</a></li>
-      </ul>
+      <p class="p-heading--four">If you are contributing to Vanilla, there are two guideline documents that you need to follow, that align with the practices that the Canonical Web Team follows across all projects.</p>
     </div>
+  </div>
+  <div class="row">
+    <h2 class="p-heading--four">Guidelines</h2>
+    <ul class="p-inline-list">
+      <li class="p-inline-list__item"><a class="p-link--external" href="https://github.com/canonical-webteam/practices/blob/master/coding/html.md">HTML code standards</a></li>
+      <li class="p-inline-list__item"><a class="p-link--external" href="https://github.com/canonical-webteam/practices/blob/master/coding/stylesheets.md">Stylesheets code standards</a></li>
+    </ul>
   </div>
 </div>


### PR DESCRIPTION
## Done

Updated the styling of the coding standards page

## QA

 - `./run`
 - Go to /coding-standards
 - Check against [design in the issue](https://app.zenhub.com/workspace/o/canonical-websites/vanillaframework.io/issues/138) (NOTE: the text-width is constrained but I'm going to leave this until it's fixed upstream rather than making a temporary hack)

## Issue / Card

Fixes #138 