### PR TITLE
Update Who's Using Vanilla logos and reorder

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,13 +153,7 @@ sitemap:
     <div class="col-12">
       <ul class="p-inline-images">
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical" />
-        </li>
-        <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/adac6928-ubuntu.svg" alt="Ubuntu" />
-        </li>
-        <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/4a93b95f-landscape_black-orange_hex.svg" alt="Landscape" />
         </li>
         <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/4cd5caa2-maas_black-orange_hex.svg" alt="MAAS" />
@@ -168,16 +162,19 @@ sitemap:
           <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/e2ac88af-juju_black-orange_hex.svg" alt="Juju" />
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/5051e6e5-core_logo.svg" alt="Ubuntu Core" />
+          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/ea4e7803-snapcraft_green-red_su_hex_cropped.svg" alt="Snapcraft" />
+        </li>
+        <li class="p-inline-images__item">
+          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/ac9a0e00-lxd_primary.svg" alt="LXD" />
         </li>
         <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/8c237d84-conjure-up-logo-black.svg" alt="Conjure Up" />
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/ea4e7803-snapcraft_green-red_su_hex_cropped.svg" alt="Snapcraft" />
+          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d9c7e58e-cloud-init-logo-updated.svg" alt="Cloud Init" />
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d9c7e58e-cloud-init-logo-updated.svg" alt="Cloud Init" />
+          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/5d6da5c4-logo-canonical-aubergine.svg" alt="Canonical" />
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Done

Updated the Who's Using Vanilla logo list

## QA

- `./run`
- Visit homapage
- Check the list of icons against the [design](https://app.zenhub.com/workspace/o/canonical-websites/vanillaframework.io/issues/156)

## Issue / Card

Fixes #156 
