### PR TITLE
Update GA events on homepage hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,10 @@ sitemap:
     <h1 class="p-heading--stylized">Vanilla is a simple extensible CSS framework, written in Sass, by the Ubuntu Web Team</h1>
     <ul class="p-inline-list">
       <li class="p-inline-list__item">
-        <a href="https://github.com/vanilla-framework/vanilla-framework" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Docs link', 'eventLabel' : 'See the docs', 'eventValue' : undefined });" class="p-button--neutral p-link--external u-no-margin--bottom">Download v1.8.0</a>
+        <a href="https://github.com/vanilla-framework/vanilla-framework" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download v1.8.0', 'eventValue' : undefined });" class="p-button--neutral p-link--external u-no-margin--bottom">Download v1.8.0</a>
       </li>
       <li class="p-inline-list__item">
-        <a href="https://docs.vanillaframework.io/en/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'GitHub link', 'eventLabel' : 'Vanilla on GitHub', 'eventValue' : undefined });" class="p-link p-link--inverted">See the docs</a>
+        <a href="https://docs.vanillaframework.io/en/" onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Docs link', 'eventLabel' : 'See the docs', 'eventValue' : undefined });" class="p-link p-link--inverted">See the docs</a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
## Done

- Updated GA event for new CTA 'Download v1.8.0' homepage hero
- Updated GA event for existing 'See the docs' link

## QA
Check onclick events have been added to buttons/links on the homepage.
- 'eventCategory', eventAction' and 'eventLabel'
## Issue / Card

N/A

## Screenshots

N/A