### PR TITLE
Update submit new issue URL

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,7 @@
             <a class="p-footer__link" href="https://www.ubuntu.com/legal">Legal info</a>
           </li>
           <li class="p-footer__item">
-            <a class="p-footer__link" href="https://github.com/canonical-websites/vanillaframework.io/issues/new">Report a bug with this site</a>
+            <a class="p-footer__link" href="https://github.com/vanilla-framework/vanilla-framework/issues/new/choose">Report a bug with this site</a>
           </li>
           <li class="p-footer__item">
             <a class="p-footer__link" href="https://github.com/vanilla-framework/vanilla-framework/issues/new">Report a bug with Vanilla framework</a>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,10 +8,10 @@
             <a class="p-footer__link" href="https://www.ubuntu.com/legal">Legal info</a>
           </li>
           <li class="p-footer__item">
-            <a class="p-footer__link" href="https://github.com/vanilla-framework/vanilla-framework/issues/new/choose">Report a bug with this site</a>
+            <a class="p-footer__link" href="https://github.com/canonical-websites/vanillaframework.io/issues/new">Report a bug with this site</a>
           </li>
           <li class="p-footer__item">
-            <a class="p-footer__link" href="https://github.com/vanilla-framework/vanilla-framework/issues/new">Report a bug with Vanilla framework</a>
+            <a class="p-footer__link" href="https://github.com/vanilla-framework/vanilla-framework/issues/new/choose">Report a bug with Vanilla framework</a>
           </li>
         </ul>
         <span class="u-off-screen">

--- a/contribute.html
+++ b/contribute.html
@@ -61,7 +61,7 @@ sitemap:
   </div>
   <div class="row">
     <div class="col-8">
-      <p>When <a href="https://github.com/vanilla-framework/vanilla-framework/issues/new" class="p-link--external">submitting a new issue</a>, please check that it hasn't already been raised by someone else. We've provided a template for new issues which will help you structure your issue to ensure it can be picked up and actioned easily.</p>
+      <p>When <a href="https://github.com/vanilla-framework/vanilla-framework/issues/new/choose" class="p-link--external">submitting a new issue</a>, please check that it hasn't already been raised by someone else. We've provided a template for new issues which will help you structure your issue to ensure it can be picked up and actioned easily.</p>
       <p>Please provide as much information possible detailing what you're currently experiencing and what you'd expect to experience.</p>
       <p>To work on an issue, please fork this repo and create a new branch on your local fork. When you're happy and would like to propose that changeset to be merged back upstream, open a pull request to merge from your local origin/master to upstream/master.</p>
       <p>When committing changes, make sure to group related changes so that the project is always in a working state. Use succinct yet descriptive commit messages to allow for easy reading of the commit log.</p>


### PR DESCRIPTION
## Done
Updated 'submitting a new issue' URL

## QA
- ./run
- visit /contribute page
- See that clicking '_submitting a new issue_' under **Contribute** heading points to updated URL - https://github.com/vanilla-framework/vanilla-framework/issues/new/choose

## Issue / Card
Fixes issue #173 