### PR TITLE
Add Vanilla React download to the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,23 +118,23 @@ sitemap:
     </div>
   </div>
   <div class="row">
-    <div class="col-6">
+    <div class="col-4">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a81f84ba-github-icon.svg" alt="GitHub icon">
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a81f84ba-github-icon.svg" alt="GitHub icon" style="max-height: 2.5rem; max-width: 2.5rem;">
           <h3 class="p-heading-icon__title">Vanilla Framework</h3>
         </div>
-        <p>Use our CSS framework to start building your project.</p>
+        <p>Use our CSS framework to start building&nbsp;your project.</p>
         <p class="u-no-margin--bottom">
           <a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla framework', 'eventValue' : undefined });" class="p-link--strong p-link--external" href="https://github.com/vanilla-framework/vanilla-framework">Download Vanilla Framework</a>
         </p>
-        <small>See the <a class="p-link--external" href="https://github.com/vanilla-framework/vanilla-framework/releases">release notes</a> for details on the latest updates.</small>
+        <small>See the <a class="p-link--external" href="https://github.com/vanilla-framework/vanilla-framework/releases">release notes</a> for details on the latest&nbsp;updates.</small>
       </div>
     </div>
-    <div class="col-6">
+    <div class="col-4">
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
-          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/286cacab-sketch-icon.svg" alt="Sketch icon">
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/286cacab-sketch-icon.svg" alt="Sketch icon" style="max-height: 2.5rem; max-width: 2.5rem;">
           <h3 class="p-heading-icon__title">Vanilla Design</h3>
         </div>
         <p>Get a Sketch file of common design components.</p>
@@ -142,6 +142,18 @@ sitemap:
           <a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla Design UI Kit', 'eventValue' : undefined });" class="p-link--strong p-link--external" href="https://assets.ubuntu.com/latest-redirects/vanilla-framework.sketch">Download Vanilla Design UI Kit</a>
         </p>
         <small>(2.4 MB)</small>
+      </div>
+    </div>
+    <div class="col-4">
+      <div class="p-heading-icon">
+        <div class="p-heading-icon__header">
+          <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a279238b-react-logo.svg" alt="React icon" style="max-height: 2.5rem; max-width: 2.5rem;">
+          <h3 class="p-heading-icon__title">Vanilla Storybook</h3>
+        </div>
+        <p>A simple implementation of Vanilla Framework using React.</p>
+        <p class="u-no-margin--bottom">
+          <a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla React', 'eventValue' : undefined });" class="p-link--strong p-link--external" href="https://github.com/vanilla-framework/vanilla-framework-react">Download Vanilla React</a>
+        </p>
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -148,11 +148,14 @@ sitemap:
       <div class="p-heading-icon">
         <div class="p-heading-icon__header">
           <img class="p-heading-icon__img" src="https://assets.ubuntu.com/v1/a279238b-react-logo.svg" alt="React icon" style="max-height: 2.5rem; max-width: 2.5rem;">
-          <h3 class="p-heading-icon__title">Vanilla Storybook</h3>
+          <h3 class="p-heading-icon__title">Vanilla React</h3>
         </div>
         <p>A simple implementation of Vanilla Framework using React.</p>
-        <p class="u-no-margin--bottom">
+        <p>
           <a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'Download Vanilla React', 'eventValue' : undefined });" class="p-link--strong p-link--external" href="https://github.com/vanilla-framework/vanilla-framework-react">Download Vanilla React</a>
+        </p>
+        <p class="u-no-margin--bottom">
+          <a onclick="dataLayer.push({'event' : 'GAEvent', 'eventCategory' : 'Homepage', 'eventAction' : 'Downloads', 'eventLabel' : 'View Vanilla Storybook', 'eventValue' : undefined });" class="p-link--strong p-link--external" href="https://vanilla-framework.github.io/vanilla-framework-react/?knob-Allow%20Multiple=false&knob-Title1=Title%20of%20Item%201&knob-Text1=Lorem%20Ipsum%20has%20been%20the%20industrys%20standard%20dummy%20text%20ever%20since%20the%201500s%2C%20when%20an%20unknown%20printer%20took%20a%20galley%20of%20type%20and%20scrambled%20it%20to%20make%20a%20type%20specimen%20book.&knob-Title2=Title%20of%20Item%202&knob-Text2=Lorem%20Ipsum%20has%20been%20the%20industrys%20standard%20dummy%20text%20ever%20since%20the%201500s%2C%20when%20an%20unknown%20printer%20took%20a%20galley%20of%20type%20and%20scrambled%20it%20to%20make%20a%20type%20specimen%20book.&knob-Title3=Title%20of%20Item%203&knob-Text3=Lorem%20Ipsum%20has%20been%20the%20industrys%20standard%20dummy%20text%20ever%20since%20the%201500s%2C%20when%20an%20unknown%20printer%20took%20a%20galley%20of%20type%20and%20scrambled%20it%20to%20make%20a%20type%20specimen%20book.&selectedKind=Accordion&selectedStory=Default&full=0&down=1&left=1&panelRight=1&downPanel=storybooks%2Fstorybook-addon-knobs">View Vanilla Storybook</a>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Done

Add link to download Vanilla React to the homepage

## QA

 - ./run
 - Go to the homepage
 - See that the new React download section matches the [design](https://user-images.githubusercontent.com/17748020/48722211-66563d00-ec1b-11e8-9673-09535f3c8abe.png) and [copydoc](https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g7O3rLzpg/edit#)

## Issue / Card

Fixes #168 
