### PR TITLE
Add copydoc meta tags to pages

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -12,6 +12,7 @@
     <link rel="icon" href="https://assets.ubuntu.com/v1/bbba0152-vanilla_favicon_16px.png" type="image/x-icon" />
     <title>Vanilla Framework</title>
     <meta name="description" content="Vanilla is a simple extensible CSS framework, written in Sass, by the Ubuntu Web Team">
+    {% if page.copydoc %}<meta name="copydoc" content="{{ page.copydoc }}" />{% endif %}
     <!-- Stylesheet -->
     <link rel="stylesheet" href="css/main.css" async="async">
     <!-- Crazy Egg A/B testing -->

--- a/accessibility.html
+++ b/accessibility.html
@@ -5,6 +5,7 @@ sitemap:
     priority: 1.0
     changefreq: 'monthly'
     lastmod: 2017-06-30T17:20:30+00:00
+copydoc: https://docs.google.com/document/d/1_cCvuHSwS9i0pzD_4WHDFoTenVAfZVr9qGxG-rSHHGY/edit
 ---
 
 <div id="main-content" class="p-strip--image is-dark vfio-hero">

--- a/browser-support.html
+++ b/browser-support.html
@@ -5,8 +5,8 @@ sitemap:
     priority: 1.0
     changefreq: 'monthly'
     lastmod: 2018-08-01T17:20:30+00:00
+copydoc: https://docs.google.com/document/d/1flcSinNnjOJw88ooVQfUjQW8ZDHSXOe2cTHmgwIEx6I/edit
 ---
-
 <div id="main-content" class="p-strip--image is-dark vfio-hero">
   <div class="row">
     <h1 class="p-heading--stylized u-no-margin--bottom">Browser support</h1>

--- a/coding-standards.html
+++ b/coding-standards.html
@@ -5,6 +5,7 @@ sitemap:
     priority: 1.0
     changefreq: 'monthly'
     lastmod: 2017-06-30T17:20:30+00:00
+copydoc: https://docs.google.com/document/d/1lhD_rjaKk6OHk_yeXzEqFde5lqeZ7EmgmZl5BCfPwk8/edit
 ---
 
 <div id="main-content" class="p-strip--image is-dark vfio-hero">

--- a/contribute.html
+++ b/contribute.html
@@ -5,6 +5,7 @@ sitemap:
     priority: 1.0
     changefreq: 'monthly'
     lastmod: 2017-07-03T17:20:30+00:00
+copydoc: https://docs.google.com/document/d/1FIYkjR9Xu6Or0WUCi6EQGaZsiTq8ESk8Kv39CW4kkwo/edit
 ---
 
 <div id="main-content" class="p-strip--image is-dark vfio-hero">

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@ sitemap:
     priority: 1.0
     changefreq: 'monthly'
     lastmod: 2017-01-13T17:20:30+00:00
+copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g7O3rLzpg/edit
 ---
 
 <div id="main-content" class="p-strip--image is-dark is-deep" style="background-image: url('https://assets.ubuntu.com/v1/775cc62b-vanilla-grad-background.png'); background-position: 75% 50%;">

--- a/showcase.html
+++ b/showcase.html
@@ -5,6 +5,7 @@ sitemap:
     priority: 1.0
     changefreq: 'monthly'
     lastmod: 2018-11-20T10:27:30+00:00
+copydoc: https://docs.google.com/document/d/1daLrp_H_BGhSefvrP-aj3v3505dEz-zoKF2Mar2Dpt4/edit
 ---
 
 <section id="main-content" class="p-strip--image is-dark vfio-hero">


### PR DESCRIPTION
## Done

Added meta tags to each page for the copydoc browser plugin

## QA

- Install the [extenstion](https://github.com/canonical-webteam/ubuntu-copy-docs) for your broswer
- ./run
- Go to [http://localhost:8014/](http://localhost:8014/)
- See that the copydocs appear for all page (not docs)

## Issue / Card
Fixes #166 

