### PR TITLE
Update slack icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,7 +196,7 @@ copydoc: https://docs.google.com/document/d/1WQ3u4Eg9Vqp_yFBdIYUyGXkvhMxlPBMSr7g
     <div class="col-4 p-divider__block">
       <h2 class="p-heading--three">Get involved</h2>
       <ul class="p-list--divided">
-        <li class="p-list__item is-ticked" style="background-image: url('https://assets.ubuntu.com/v1/2cc52754-Slack_Icon_Mark_Monochrome.svg'); padding-left: 2.125rem; padding-top: .55rem; background-size: 24px;">
+        <li class="p-list__item is-ticked" style="background-image: url('https://assets.ubuntu.com/v1/8a2851df-slack-icon-vanilla.svg'); padding-left: 2.125rem; padding-top: .55rem; background-size: 24px;">
           <a href="https://vanillaframework.slack.com"
             class="p-link--soft">
             Slack&nbsp;&rsaquo;


### PR DESCRIPTION
## Done
- Updated Slack icon under 'Getting help' section

## QA
- ./run
- Go to the homepage
- Scroll to 'Getting involved'
- See that the Slack logo has updated to match their rebrand
